### PR TITLE
Systree

### DIFF
--- a/cubex/calltree.py
+++ b/cubex/calltree.py
@@ -49,7 +49,7 @@ class CallTree(object):
         # TODO: Check that metric is inclusive
         # TODO: Check arguments
 
-        sloc, eloc = interval if interval else (0, -1)
+        sloc, eloc = interval if interval else (None, None)
 
         self_sum = sum(self.metrics[metric_name][sloc:eloc])
 

--- a/cubex/cube.py
+++ b/cubex/cube.py
@@ -24,7 +24,6 @@ class Cube(object):
         self.regions = {}
         self.calltrees = []
         self.systems = []
-        self.locationgrps = []  # TODO: move locationgroups inside of system
 
         # Index lookup tables (TODO: phase this out)
         self.rindex = {}
@@ -125,7 +124,7 @@ class Cube(object):
             ctree.update_index(self.cindex)
 
         # Location groups
-        self.system = System(root.find('system'), self)
+        self.system = System(root.find('system'))
 
         # TODO: Need to populate locationgroups similar to calltree
 
@@ -151,7 +150,7 @@ class Cube(object):
 
         # TODO: Store this somewhere?  Or create a property.
         n_locs = 0
-        for locgrp in self.locationgrps:
+        for locgrp in self.system.locationgroups:
             n_locs += len(locgrp.locations)
 
         for idx in metric.index:

--- a/cubex/cube.py
+++ b/cubex/cube.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ElementTree
 from cubex.metric import Metric
 from cubex.region import Region
 from cubex.calltree import CallTree
-from cubex.system import SystemNode, Location, LocationGroup
+from cubex.system import System
 
 
 class Cube(object):
@@ -54,7 +54,7 @@ class Cube(object):
 
     def read_anchor(self):
         # NOTE: Using a `with` construct here will fail on Python 2, since
-        # tarfile's ExtObject doesn't support __exit__()
+        #       tarfile's ExtObject doesn't support __exit__()
         anchor_file = self.cubex_file.extractfile('anchor.xml')
         anchor = ElementTree.parse(anchor_file)
         anchor_file.close()
@@ -79,8 +79,8 @@ class Cube(object):
 
         # Read the metric index and get the data file
         for name, metric in self.metrics.items():
-
             index_fname = '{}.index'.format(metric.idx)
+
             try:
                 m_index = self.cubex_file.extractfile(index_fname)
             except KeyError:
@@ -100,7 +100,6 @@ class Cube(object):
 
         # Regions
         for rnode in root.find('program').findall('region'):
-
             region = Region(rnode)
 
             if region.name in self.regions:
@@ -126,19 +125,13 @@ class Cube(object):
             ctree.update_index(self.cindex)
 
         # Location groups
-        # TODO: Connect nodes to processes
-        #       This is just a dump of the info
-        for snode in root.find('system').findall('systemtreenode'):
-            self.systems.append(SystemNode(snode))
+        self.system = System(root.find('system'), self)
 
-            for nnode in snode.findall('systemtreenode'):
-                for lnode in nnode.findall('locationgroup'):
-                    self.locationgrps.append(LocationGroup(lnode))
+        # TODO: Need to populate locationgroups similar to calltree
 
         # TODO: Topologies
 
     def read_data(self, metric_name):
-
         metric = self.metrics[metric_name]
 
         # Populate data

--- a/cubex/system.py
+++ b/cubex/system.py
@@ -1,24 +1,46 @@
+class System(object):
+    def __init__(self, node, cube):
+        self.nodes = []
+        for snode in node.findall('systemtreenode'):
+            self.nodes.append(SystemNode(snode, cube))
+
+
 class SystemNode(object):
-
-    def __init__(self, node):
+    def __init__(self, node, cube):
         self.name = node.find('name').text
-        self.sclass = node.find('class').text
+        self.node_class = node.find('class').text
+        self.node_id = node.attrib['Id']
+
+        self.attrs = {}
+        self.nodes = []
+        self.locationgroups = []
+
+        for attr in node.findall('attr'):
+            self.attrs[attr.attrib['key']] = attr.attrib['value']
+
+        for snode in node.findall('systemtreenode'):
+            self.nodes.append(SystemNode(snode, cube))
+
+        for locgrp in node.findall('locationgroup'):
+            self.locationgroups.append(LocationGroup(locgrp))
 
 
-class Location(object):
-
+class LocationGroup(object):
     def __init__(self, node):
         self.name = node.find('name').text
         self.rank = int(node.find('rank').text)
-        self.ltype = node.find('type').text
+        self.loc_type = node.find('type').text
+        self.loc_id = node.attrib['Id']
 
-
-class LocationGroup(Location):
-
-    def __init__(self, node):
-
-        super(LocationGroup, self).__init__(node)
         self.locations = []
 
         for loc in node.findall('location'):
             self.locations.append(Location(node.find('location')))
+
+
+class Location(object):
+    def __init__(self, node):
+        self.name = node.find('name').text
+        self.rank = int(node.find('rank').text)
+        self.loc_type = node.find('type').text
+        self.loc_id = node.attrib['Id']

--- a/cubex/system.py
+++ b/cubex/system.py
@@ -1,12 +1,18 @@
 class System(object):
-    def __init__(self, node, cube):
+    def __init__(self, node):
         self.nodes = []
+
+        # Storing locationgroups and locations at toplevel
+        # NOTE: Not sure this is what I want to do yet...
+        self.locationgroups = []
+        self.locations = []
+
         for snode in node.findall('systemtreenode'):
-            self.nodes.append(SystemNode(snode, cube))
+            self.nodes.append(SystemNode(snode, self))
 
 
 class SystemNode(object):
-    def __init__(self, node, cube):
+    def __init__(self, node, system):
         self.name = node.find('name').text
         self.node_class = node.find('class').text
         self.node_id = node.attrib['Id']
@@ -19,23 +25,27 @@ class SystemNode(object):
             self.attrs[attr.attrib['key']] = attr.attrib['value']
 
         for snode in node.findall('systemtreenode'):
-            self.nodes.append(SystemNode(snode, cube))
+            self.nodes.append(SystemNode(snode, system))
 
-        for locgrp in node.findall('locationgroup'):
-            self.locationgroups.append(LocationGroup(locgrp))
+        for locgrp_node in node.findall('locationgroup'):
+            locgrp = LocationGroup(locgrp_node, system)
+            self.locationgroups.append(locgrp)
+            system.locationgroups.append(locgrp)
 
 
 class LocationGroup(object):
-    def __init__(self, node):
+    def __init__(self, node, system):
         self.name = node.find('name').text
         self.rank = int(node.find('rank').text)
-        self.loc_type = node.find('type').text
-        self.loc_id = node.attrib['Id']
+        self.grp_type = node.find('type').text
+        self.grp_id = node.attrib['Id']
 
         self.locations = []
 
-        for loc in node.findall('location'):
-            self.locations.append(Location(node.find('location')))
+        for loc_node in node.findall('location'):
+            loc = Location(loc_node)
+            self.locations.append(loc)
+            system.locations.append(loc)
 
 
 class Location(object):


### PR DESCRIPTION
This patch replaces the assumed-flat system node layout with a
hierarchical tree.  Previously (on NCI) it was assumed that there was a
single system node, which then contained a flat list of location groups,
each containing a flat list of locations.

On more complex machines for which Score-P is more attuned, there is a
deeper hierarchy of system nodes, which can contain information about
intermediate points such as network switches.  This was causing cubex to
fail, since there were no location groups inside the top-level system
group.

We have resolved this by replacing the system node parsing with a
recursive parser.  We still force all of the location groups into a list
whose indices are not matched to their Ids.  Although at first glance
they appear to be correct, this should be addressed in the future.

----

We have also fixed a bug in the `print_weights` function, which was not
including the final rank in its averaged metric reports.  In addition to
being incorrect, this was causing runtime-fails in single-rank tests.